### PR TITLE
Markdown to txt output alongside html

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -27,6 +27,9 @@ site.copy("assets");
 site.copy("scripts");
 site.copy("PaulFischerResume.pdf");
 
+// Copy images from post subdirectories
+site.copy([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+
 // post related content to copy
 site.copy("posts/generate-todo-with-ai/gpt-todo.html")
 

--- a/_config.ts
+++ b/_config.ts
@@ -12,6 +12,7 @@ import readInfo from "lume/plugins/reading_info.ts";
 import inline from "lume/plugins/inline.ts";
 import minifyHTML from "lume/plugins/minify_html.ts";
 import lightningCss from "lume/plugins/lightningcss.ts";
+import txtOutput from "./_plugins/txt_output.ts";
 
 import lang_csharp from "npm:highlight.js/lib/languages/csharp";
 
@@ -75,10 +76,11 @@ site.use(code_highlight({
   },
 }));
 site.use(jsx());
-site.use(inline());
 site.use(tailwindcss());
 site.use(lightningCss());
+site.use(inline());
 site.add("styles.css");
 site.use(minifyHTML());
+site.use(txtOutput());
 
 export default site;

--- a/_includes/layouts/posts.tsx
+++ b/_includes/layouts/posts.tsx
@@ -1,6 +1,6 @@
 export const layout = "layouts/main.tsx";
 
-export default ({ title, children, github, author, date, tags, categories, comp }: Lume.Data, { date: helperDate }: Lume.Helpers) => (
+export default ({ title, children, github, author, date, tags, categories, comp, url }: Lume.Data, { date: helperDate }: Lume.Helpers) => (
   <>
     <div className="flex flex-col gap-4 lg:gap-2">
       <h1 className="mt-4 text-6xl dark:text-slate-400">{title}</h1>
@@ -15,6 +15,7 @@ export default ({ title, children, github, author, date, tags, categories, comp 
         <div>
           Posted <span>{helperDate(date, 'MM/dd/yyyy')}</span>
         </div>
+        <a href={`${url}/index.txt`} className="text-blue-600 dark:text-blue-400">Text Version</a>
       </div>
       <div className="border-b border-solid border-slate-700"></div>
       <div id="post-content" className="dark:bg-zinc-900 overflow-auto">

--- a/_plugins/txt_output.ts
+++ b/_plugins/txt_output.ts
@@ -25,23 +25,18 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
         let textContent = page.data.content as string;
 
         // Preserve code blocks first (before other processing)
+        // The content already has markdown code blocks (```), not HTML pre/code tags
         const codeBlocks: string[] = [];
         textContent = textContent.replace(
-          /<pre[^>]*>.*?<\/pre>/gis,
+          /```[\s\S]*?```/g,
           (match) => {
             const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
-            // Extract text content from code block
-            const code = match
-              .replace(/<pre[^>]*>/i, "")
-              .replace(/<\/pre>/i, "")
-              .replace(/<code[^>]*>/i, "")
-              .replace(/<\/code>/i, "")
-              .replace(/&lt;/g, "<")
-              .replace(/&gt;/g, ">")
-              .replace(/&amp;/g, "&")
-              .replace(/&quot;/g, '"')
-              .trim();
-            codeBlocks.push("\n```\n" + code + "\n```\n");
+            // Extract the code block content (everything between the backticks)
+            const lines = match.split('\n');
+            // Remove the first line (```language) and last line (```)
+            const code = lines.slice(1, -1).join('\n').trim();
+            // Store code block - we'll indent it when we restore it
+            codeBlocks.push(code);
             return placeholder;
           },
         );
@@ -135,18 +130,22 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
           .replace(/&mdash;/g, "—")
           .replace(/&ndash;/g, "–");
 
-        // Restore code blocks
-        codeBlocks.forEach((code, i) => {
-          textContent = textContent.replace(`__CODE_BLOCK_${i}__`, code);
-        });
-
         // Clean up excessive whitespace while preserving intentional spacing
+        // Do this BEFORE restoring code blocks to avoid stripping their indentation
         textContent = textContent
           .split("\n")
           .map((line) => line.trim())
           .join("\n")
           .replace(/\n{3,}/g, "\n\n")
           .trim();
+
+        // Restore code blocks (after cleanup, with indentation applied here)
+        codeBlocks.forEach((code, i) => {
+          // Indent each line by 4 spaces and wrap in code fence
+          const indentedCode = code.split("\n").map(line => "    " + line).join("\n");
+          const codeBlock = "\n```\n" + indentedCode + "\n```\n";
+          textContent = textContent.replace(`__CODE_BLOCK_${i}__`, codeBlock);
+        });
 
         // Add metadata header if enabled
         let finalContent = "";

--- a/_plugins/txt_output.ts
+++ b/_plugins/txt_output.ts
@@ -61,11 +61,25 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
           },
         );
 
-        // Convert markdown links to plain text with URL
+        // Convert markdown links to plain text with full URL
         textContent = textContent.replace(
           /\[([^\]]+)\]\(([^)]+)\)/g,
           (_match, text: string, href: string) => {
-            return text ? `${text} (${href})` : href;
+            let fullUrl = href;
+            // Only convert relative or absolute paths to full URLs if they're not already absolute URLs
+            if (!href.startsWith('http://') && !href.startsWith('https://') && !href.startsWith('//')) {
+              // Construct the full URL using the site's location
+              if (href.startsWith('/')) {
+                // Absolute path - combine with site location
+                fullUrl = new URL(href, site.options.location).href;
+              } else {
+                // Relative path - resolve relative to current page's directory
+                const pageDir = page.data.url?.replace(/[^/]*$/, '') || '/';
+                const resolvedPath = new URL(href, `https://example.com${pageDir}`).pathname;
+                fullUrl = new URL(resolvedPath, site.options.location).href;
+              }
+            }
+            return text ? `${text} (${fullUrl})` : fullUrl;
           },
         );
 

--- a/_plugins/txt_output.ts
+++ b/_plugins/txt_output.ts
@@ -7,12 +7,15 @@ interface TxtOutputOptions {
   filter?: (page: Page) => boolean;
   // Whether to include metadata at the top
   includeMetadata?: boolean;
+  // Whether to include image URLs (if false, only shows alt text)
+  includeImageUrls?: boolean;
 }
 
 export default function txtOutput(options: TxtOutputOptions = {}) {
   const defaults: Required<TxtOutputOptions> = {
     filter: (page: Page) => page.data.url?.startsWith("/posts/") ?? false,
     includeMetadata: true,
+    includeImageUrls: true,
   };
 
   const opts = { ...defaults, ...options };
@@ -36,11 +39,25 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
           },
         );
 
-        // Convert markdown images to links
+        // Convert markdown images
         textContent = textContent.replace(
           /!\[([^\]]*)\]\(([^)]+)\)(\{[^}]+\})?/g,
           (_match, alt: string, src: string) => {
-            return alt ? `[Image: ${alt}](${src})` : `[Image](${src})`;
+            if (!opts.includeImageUrls) {
+              // Just show alt text, skip the URL
+              return alt ? `[Image: ${alt}]` : "[Image]";
+            }
+            // Include the image URL
+            let fullUrl = src;
+            if (!src.startsWith('http://') && !src.startsWith('https://') && !src.startsWith('//')) {
+              // Get the directory of the current page
+              const pageDir = page.data.url?.replace(/[^/]*$/, '') || '/';
+              // Resolve relative path
+              const resolvedPath = new URL(src, `https://example.com${pageDir}`).pathname;
+              // Combine with site location
+              fullUrl = new URL(resolvedPath, site.options.location).href;
+            }
+            return alt ? `[Image: ${alt}](${fullUrl})` : `[Image](${fullUrl})`;
           },
         );
 
@@ -58,10 +75,13 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
         textContent = textContent.replace(/^# /gm, "\n\n# ");
 
         // Convert markdown bold and italic
+        // Stars: remove safely (not used in URLs)
         textContent = textContent.replace(/\*\*([^*]+)\*\*/g, "$1");
         textContent = textContent.replace(/\*([^*]+)\*/g, "$1");
-        textContent = textContent.replace(/__([^_]+)__/g, "$1");
-        textContent = textContent.replace(/_([^_]+)_/g, "$1");
+        // Underscore emphasis: avoid touching URLs or identifiers
+        // Only match underscores that are not adjacent to word characters
+        textContent = textContent.replace(/(^|[^\w])__([^_]+)__(?=[^\w]|$)/g, "$1$2");
+        textContent = textContent.replace(/(^|[^\w])_([^_]+)_(?=[^\w]|$)/g, "$1$2");
 
         // Convert markdown lists
         textContent = textContent.replace(/^\s*[-*+] /gm, "• ");

--- a/_plugins/txt_output.ts
+++ b/_plugins/txt_output.ts
@@ -18,7 +18,7 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
   const opts = { ...defaults, ...options };
 
   return (site: Site) => {
-    site.process([".html"], (pages: Page[], allPages: Page[]) => {
+    site.process([".md"], (pages: Page[], allPages: Page[]) => {
       for (const page of pages) {
         if (!opts.filter(page)) continue;
 
@@ -30,105 +30,45 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
         textContent = textContent.replace(
           /```[\s\S]*?```/g,
           (match) => {
-            const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
-            // Extract the code block content (everything between the backticks)
-            const lines = match.split('\n');
-            // Remove the first line (```language) and last line (```)
-            const code = lines.slice(1, -1).join('\n').trim();
-            // Store code block - we'll indent it when we restore it
-            codeBlocks.push(code);
+            const placeholder = `@@CODEBLOCK${codeBlocks.length}@@`;
+            codeBlocks.push(match);
             return placeholder;
           },
         );
 
-        // Convert images to links
+        // Convert markdown images to links
         textContent = textContent.replace(
-          /<img[^>]*src=["']([^"']+)["'][^>]*alt=["']([^"']*)["'][^>]*>/gi,
-          (_match, src: string, alt: string) => {
+          /!\[([^\]]*)\]\(([^)]+)\)(\{[^}]+\})?/g,
+          (_match, alt: string, src: string) => {
             return alt ? `[Image: ${alt}](${src})` : `[Image](${src})`;
           },
         );
-        // Handle images without alt text
+
+        // Convert markdown links to plain text with URL
         textContent = textContent.replace(
-          /<img[^>]*src=["']([^"']+)["'][^>]*>/gi,
-          (match, src: string) => {
-            if (match.includes("alt=")) return match; // Already processed
-            return `[Image](${src})`;
+          /\[([^\]]+)\]\(([^)]+)\)/g,
+          (_match, text: string, href: string) => {
+            return text ? `${text} (${href})` : href;
           },
         );
 
-        // Convert links to preserve them
-        textContent = textContent.replace(
-          /<a[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi,
-          (_match, href: string, text: string) => {
-            const linkText = text.replace(/<[^>]+>/g, "").trim();
-            return linkText ? `${linkText} (${href})` : href;
-          },
-        );
+        // Convert markdown headings
+        textContent = textContent.replace(/^### /gm, "\n\n### ");
+        textContent = textContent.replace(/^## /gm, "\n\n## ");
+        textContent = textContent.replace(/^# /gm, "\n\n# ");
 
-        // Convert headings to preserve hierarchy
-        textContent = textContent.replace(
-          /<h1[^>]*>(.*?)<\/h1>/gi,
-          "\n\n# $1\n\n",
-        );
-        textContent = textContent.replace(
-          /<h2[^>]*>(.*?)<\/h2>/gi,
-          "\n\n## $1\n\n",
-        );
-        textContent = textContent.replace(
-          /<h3[^>]*>(.*?)<\/h3>/gi,
-          "\n\n### $1\n\n",
-        );
-        textContent = textContent.replace(
-          /<h4[^>]*>(.*?)<\/h4>/gi,
-          "\n\n#### $1\n\n",
-        );
-        textContent = textContent.replace(
-          /<h5[^>]*>(.*?)<\/h5>/gi,
-          "\n\n##### $1\n\n",
-        );
-        textContent = textContent.replace(
-          /<h6[^>]*>(.*?)<\/h6>/gi,
-          "\n\n###### $1\n\n",
-        );
+        // Convert markdown bold and italic
+        textContent = textContent.replace(/\*\*([^*]+)\*\*/g, "$1");
+        textContent = textContent.replace(/\*([^*]+)\*/g, "$1");
+        textContent = textContent.replace(/__([^_]+)__/g, "$1");
+        textContent = textContent.replace(/_([^_]+)_/g, "$1");
 
-        // Convert paragraphs and divs to preserve spacing
-        textContent = textContent.replace(/<\/p>/gi, "\n\n");
-        textContent = textContent.replace(/<p[^>]*>/gi, "");
-        textContent = textContent.replace(/<\/div>/gi, "\n");
-        textContent = textContent.replace(/<div[^>]*>/gi, "");
+        // Convert markdown lists
+        textContent = textContent.replace(/^\s*[-*+] /gm, "• ");
 
-        // Convert breaks
-        textContent = textContent.replace(/<br\s*\/?>/gi, "\n");
-
-        // Convert list items
-        textContent = textContent.replace(/<li[^>]*>/gi, "\n• ");
-        textContent = textContent.replace(/<\/li>/gi, "");
-        textContent = textContent.replace(/<\/?[uo]l[^>]*>/gi, "\n");
-
-        // Remove script and style tags
-        textContent = textContent.replace(
-          /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-          "",
-        );
-        textContent = textContent.replace(
-          /<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi,
-          "",
-        );
-
-        // Remove remaining HTML tags
-        textContent = textContent.replace(/<[^>]+>/g, "");
-
-        // Decode HTML entities
-        textContent = textContent
-          .replace(/&nbsp;/g, " ")
-          .replace(/&lt;/g, "<")
-          .replace(/&gt;/g, ">")
-          .replace(/&amp;/g, "&")
-          .replace(/&quot;/g, '"')
-          .replace(/&#39;/g, "'")
-          .replace(/&mdash;/g, "—")
-          .replace(/&ndash;/g, "–");
+        // Remove remaining markdown syntax
+        textContent = textContent.replace(/`([^`]+)`/g, "$1"); // inline code
+        textContent = textContent.replace(/~~([^~]+)~~/g, "$1"); // strikethrough
 
         // Clean up excessive whitespace while preserving intentional spacing
         // Do this BEFORE restoring code blocks to avoid stripping their indentation
@@ -141,10 +81,8 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
 
         // Restore code blocks (after cleanup, with indentation applied here)
         codeBlocks.forEach((code, i) => {
-          // Indent each line by 4 spaces and wrap in code fence
-          const indentedCode = code.split("\n").map(line => "    " + line).join("\n");
-          const codeBlock = "\n```\n" + indentedCode + "\n```\n";
-          textContent = textContent.replace(`__CODE_BLOCK_${i}__`, codeBlock);
+          // Put the original fenced block back (keeps language annotation and spacing)
+          textContent = textContent.replace(`@@CODEBLOCK${i}@@`, `\n${code}\n`);
         });
 
         // Add metadata header if enabled
@@ -165,11 +103,16 @@ export default function txtOutput(options: TxtOutputOptions = {}) {
 
         finalContent += textContent;
 
-        // Create the .txt page
-        const txtUrl = page.data.url?.replace(/\.html$/, ".txt").replace(
-          /\/$/,
-          "/index.txt",
-        );
+        // Create the .txt page without colliding with the HTML output path
+        let txtUrl = page.data.url;
+        if (txtUrl?.endsWith("/")) {
+          txtUrl = txtUrl + "index.txt";
+        } else {
+          txtUrl = txtUrl
+            ?.replace(/\/index\.html$/, "/index.txt")
+            .replace(/\.html$/, ".txt")
+            .replace(/\.md$/, ".txt");
+        }
 
         if (txtUrl) {
           // Create a new page using the Page.create() method

--- a/_plugins/txt_output.ts
+++ b/_plugins/txt_output.ts
@@ -1,0 +1,189 @@
+// _plugins/txt_output.ts
+import type { Page, Site } from "lume/core.ts";
+import { Page as PageClass } from "lume/core/file.ts";
+
+interface TxtOutputOptions {
+  // Filter function to determine which pages to process
+  filter?: (page: Page) => boolean;
+  // Whether to include metadata at the top
+  includeMetadata?: boolean;
+}
+
+export default function txtOutput(options: TxtOutputOptions = {}) {
+  const defaults: Required<TxtOutputOptions> = {
+    filter: (page: Page) => page.data.url?.startsWith("/posts/") ?? false,
+    includeMetadata: true,
+  };
+
+  const opts = { ...defaults, ...options };
+
+  return (site: Site) => {
+    site.process([".html"], (pages: Page[], allPages: Page[]) => {
+      for (const page of pages) {
+        if (!opts.filter(page)) continue;
+
+        let textContent = page.data.content as string;
+
+        // Preserve code blocks first (before other processing)
+        const codeBlocks: string[] = [];
+        textContent = textContent.replace(
+          /<pre[^>]*>.*?<\/pre>/gis,
+          (match) => {
+            const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
+            // Extract text content from code block
+            const code = match
+              .replace(/<pre[^>]*>/i, "")
+              .replace(/<\/pre>/i, "")
+              .replace(/<code[^>]*>/i, "")
+              .replace(/<\/code>/i, "")
+              .replace(/&lt;/g, "<")
+              .replace(/&gt;/g, ">")
+              .replace(/&amp;/g, "&")
+              .replace(/&quot;/g, '"')
+              .trim();
+            codeBlocks.push("\n```\n" + code + "\n```\n");
+            return placeholder;
+          },
+        );
+
+        // Convert images to links
+        textContent = textContent.replace(
+          /<img[^>]*src=["']([^"']+)["'][^>]*alt=["']([^"']*)["'][^>]*>/gi,
+          (_match, src: string, alt: string) => {
+            return alt ? `[Image: ${alt}](${src})` : `[Image](${src})`;
+          },
+        );
+        // Handle images without alt text
+        textContent = textContent.replace(
+          /<img[^>]*src=["']([^"']+)["'][^>]*>/gi,
+          (match, src: string) => {
+            if (match.includes("alt=")) return match; // Already processed
+            return `[Image](${src})`;
+          },
+        );
+
+        // Convert links to preserve them
+        textContent = textContent.replace(
+          /<a[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi,
+          (_match, href: string, text: string) => {
+            const linkText = text.replace(/<[^>]+>/g, "").trim();
+            return linkText ? `${linkText} (${href})` : href;
+          },
+        );
+
+        // Convert headings to preserve hierarchy
+        textContent = textContent.replace(
+          /<h1[^>]*>(.*?)<\/h1>/gi,
+          "\n\n# $1\n\n",
+        );
+        textContent = textContent.replace(
+          /<h2[^>]*>(.*?)<\/h2>/gi,
+          "\n\n## $1\n\n",
+        );
+        textContent = textContent.replace(
+          /<h3[^>]*>(.*?)<\/h3>/gi,
+          "\n\n### $1\n\n",
+        );
+        textContent = textContent.replace(
+          /<h4[^>]*>(.*?)<\/h4>/gi,
+          "\n\n#### $1\n\n",
+        );
+        textContent = textContent.replace(
+          /<h5[^>]*>(.*?)<\/h5>/gi,
+          "\n\n##### $1\n\n",
+        );
+        textContent = textContent.replace(
+          /<h6[^>]*>(.*?)<\/h6>/gi,
+          "\n\n###### $1\n\n",
+        );
+
+        // Convert paragraphs and divs to preserve spacing
+        textContent = textContent.replace(/<\/p>/gi, "\n\n");
+        textContent = textContent.replace(/<p[^>]*>/gi, "");
+        textContent = textContent.replace(/<\/div>/gi, "\n");
+        textContent = textContent.replace(/<div[^>]*>/gi, "");
+
+        // Convert breaks
+        textContent = textContent.replace(/<br\s*\/?>/gi, "\n");
+
+        // Convert list items
+        textContent = textContent.replace(/<li[^>]*>/gi, "\n• ");
+        textContent = textContent.replace(/<\/li>/gi, "");
+        textContent = textContent.replace(/<\/?[uo]l[^>]*>/gi, "\n");
+
+        // Remove script and style tags
+        textContent = textContent.replace(
+          /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+          "",
+        );
+        textContent = textContent.replace(
+          /<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi,
+          "",
+        );
+
+        // Remove remaining HTML tags
+        textContent = textContent.replace(/<[^>]+>/g, "");
+
+        // Decode HTML entities
+        textContent = textContent
+          .replace(/&nbsp;/g, " ")
+          .replace(/&lt;/g, "<")
+          .replace(/&gt;/g, ">")
+          .replace(/&amp;/g, "&")
+          .replace(/&quot;/g, '"')
+          .replace(/&#39;/g, "'")
+          .replace(/&mdash;/g, "—")
+          .replace(/&ndash;/g, "–");
+
+        // Restore code blocks
+        codeBlocks.forEach((code, i) => {
+          textContent = textContent.replace(`__CODE_BLOCK_${i}__`, code);
+        });
+
+        // Clean up excessive whitespace while preserving intentional spacing
+        textContent = textContent
+          .split("\n")
+          .map((line) => line.trim())
+          .join("\n")
+          .replace(/\n{3,}/g, "\n\n")
+          .trim();
+
+        // Add metadata header if enabled
+        let finalContent = "";
+        if (opts.includeMetadata && page.data) {
+          const metadata: string[] = [];
+          if (page.data.title) metadata.push(`Title: ${page.data.title}`);
+          if (page.data.date) metadata.push(`Date: ${page.data.date}`);
+          if (page.data.author) metadata.push(`Author: ${page.data.author}`);
+          if (page.data.tags && Array.isArray(page.data.tags)) {
+            metadata.push(`Tags: ${page.data.tags.join(", ")}`);
+          }
+
+          if (metadata.length > 0) {
+            finalContent = metadata.join("\n") + "\n" + "=".repeat(50) + "\n\n";
+          }
+        }
+
+        finalContent += textContent;
+
+        // Create the .txt page
+        const txtUrl = page.data.url?.replace(/\.html$/, ".txt").replace(
+          /\/$/,
+          "/index.txt",
+        );
+
+        if (txtUrl) {
+          // Create a new page using the Page.create() method
+          const txtPage = PageClass.create({
+            url: txtUrl,
+            content: finalContent,
+          });
+          
+          // Add the new page to allPages
+          allPages.push(txtPage);
+          console.log(`🔥 ${txtUrl} <- ${page.data.url}`);
+        }
+      }
+    });
+  };
+}

--- a/deno.lock
+++ b/deno.lock
@@ -2989,6 +2989,7 @@
     "https://deno.land/x/lume@v3.0.11/deps/vento.ts": "78db4022ee124fbcfd84caeb6c5a70f2c1e1706ec9f6415d0f1fe2e9aabcba2b",
     "https://deno.land/x/lume@v3.0.11/deps/xml.ts": "7a8a0b3564b5aa2b80b09120246c37d5f78690a90bf7c0a41c2b6e78e195f758",
     "https://deno.land/x/lume@v3.0.11/deps/yaml.ts": "a639f4fc44ddcfc87f35e38980bbe9fc8101bf8ce34867522e76cc13cb156611",
+    "https://deno.land/x/lume@v3.0.11/lint.ts": "23cf68a7cc17edfdb16f2e905de3c5d5a1da541638f04fb8f7d5c762288f2c52",
     "https://deno.land/x/lume@v3.0.11/middlewares/basic_auth.ts": "c18f0da9f88be4581e5e3da99214fd7abdad829ab00dbdd2fb3116f1f876add2",
     "https://deno.land/x/lume@v3.0.11/middlewares/logger.ts": "c96f1a9f9d5757555b6f141865ce8551ac176f90c8ee3e9ad797b2b400a9a567",
     "https://deno.land/x/lume@v3.0.11/middlewares/no_cache.ts": "0119e3ae3a596ab12c42df693b93e5b03dd9608e289d862242751a9739438f35",

--- a/posts/text-versions-of-posts/index.md
+++ b/posts/text-versions-of-posts/index.md
@@ -1,0 +1,19 @@
+---
+title: Text output of Blog posts
+layout: layouts/posts.tsx
+url: './index.html'
+date: 2026-01-19T09:35:00Z
+categories:
+  - Hosting
+tags:
+  - blogging
+  - text
+  - html
+---
+I recently stumbled upon this blog post by [Terence Eden](https://shkspr.mobi/blog/2025/12/a-small-collection-of-text-only-websites/) about serving up blog posts not only as html but also as plain text files.  I like the idea of being able to serve up just text. I have been on this drive lately to try to reduce the size and complexity of pages I serve up lately with personal projects and what better way than just text! Basically serve up as little as possible and preferably little to no javascript.
+
+Yes, it kind of defeats the whole point of the web and serving up more stylish and dynamic pages to view.  And makes putting pictures in a blog post pointless since a text files cannot display an image but if anything, you can put a hyperlink to the image in the text file.
+
+So I have now made all my blog posts output as html as well as a text file.  Every post can be viewed by adding `index.txt` after the slash. For example, to view this as text you can view it at [posts/text-versions-of-posts/index.txt](/posts/text-versions-of-posts/index.txt)
+
+To be able to make this work with [Lume](https://lume.land/), I created a plugin that converts the original markdown file of the blog post to plain text.  It keeps code blocks around to make things more readable and converts any images or links to just the link so it can still be viewed. The plugin that generates text from markdown can be viewed [here](https://github.com/paulmfischer/fear-of-the-undefined/_plugins/txt_output.ts)  I have also update the blog to have a link to the text version at the top of every page for easy access.


### PR DESCRIPTION
This pull request adds support for generating plain text versions of all blog posts, making them accessible alongside the HTML versions. It introduces a custom Lume plugin to convert Markdown posts to `.txt` files, adds a link to the text version on each post, and updates the configuration to ensure correct copying of image assets.

**Text output and plugin integration:**

* Added a new Lume plugin (`_plugins/txt_output.ts`) that processes Markdown blog posts and generates corresponding `.txt` files, converting Markdown to readable plain text, preserving code blocks, and handling links and images appropriately.
* Integrated the new `txtOutput` plugin into the Lume site configuration in `_config.ts`. [[1]](diffhunk://#diff-f2f99a9640bcd318cf47b572d290eb80962d4e04e3d212fead03514d7d29dee1R15) [[2]](diffhunk://#diff-f2f99a9640bcd318cf47b572d290eb80962d4e04e3d212fead03514d7d29dee1L78-R87)

**Post layout and navigation:**

* Updated the post layout (`_includes/layouts/posts.tsx`) to include a "Text Version" link at the top of each post, pointing to the `.txt` version of the current post. [[1]](diffhunk://#diff-177c15a51e815bc95213e68061dc843d385c4c1974341df74818c070edeb3355L3-R3) [[2]](diffhunk://#diff-177c15a51e815bc95213e68061dc843d385c4c1974341df74818c070edeb3355R18)

**Content and documentation:**

* Added a new blog post (`posts/text-versions-of-posts/index.md`) explaining the motivation and implementation of serving blog posts as plain text files.

**Asset handling:**

* Updated `_config.ts` to copy image files from all subdirectories, ensuring images referenced in posts are available for both HTML and text versions.